### PR TITLE
Fix validation was fired twice

### DIFF
--- a/dist/ng-iban.js
+++ b/dist/ng-iban.js
@@ -308,39 +308,21 @@
           }
           return __modulo(parseInt(remainder, 10), 97) === 1;
         };
-        ctrl.$parsers.unshift(function(viewValue) {
+
+        ctrl.$validators.ngIban = function(viewValue) {
           var parsed, valid;
           if (viewValue != null) {
             valid = isValidIban(viewValue);
-            ctrl.$setValidity('iban', valid);
             if (valid) {
               parsed = parseIban(viewValue);
               if (parsed !== viewValue) {
                 ctrl.$setViewValue(parsed);
                 ctrl.$render();
               }
-              return parsed;
-            } else {
-              return void 0;
             }
           }
-        });
-        return ctrl.$formatters.unshift(function(modelValue) {
-          var parsed, valid;
-          if (modelValue != null) {
-            valid = isValidIban(modelValue);
-            ctrl.$setValidity('iban', valid);
-            if (valid) {
-              parsed = parseIban(modelValue);
-              if (parsed !== modelValue) {
-                scope[attrs.ngModel] = parsed;
-              }
-              return parsed;
-            } else {
-              return modelValue;
-            }
-          }
-        });
+          return valid;
+        };
       }
     };
   }]).directive('countrycodecheck', function (){


### PR DESCRIPTION
We have found that the validation was fired twice (issue when e.g. using a summary error validation count control), approach followed:

[http://stackoverflow.com/questions/28792954/custom-validator-directive-combined-with-other-directive-fires-multiple-times](http://stackoverflow.com/questions/28792954/custom-validator-directive-combined-with-other-directive-fires-multiple-times)

Unit tests checked and passing.
